### PR TITLE
Not compatible to Laravel v8.17.0

### DIFF
--- a/src/Database/SOQLHasOneOrMany.php
+++ b/src/Database/SOQLHasOneOrMany.php
@@ -367,9 +367,9 @@ abstract class SOQLHasOneOrMany extends Relation
 	 *
 	 * @return string
 	 */
-	public function getRelationCountHash()
+	public function getRelationCountHash($incrementJoinCount = true)
 	{
-		return 'laravel_reserved_' . static::$selfJoinCount++;
+		return 'laravel_reserved_' . ($incrementJoinCount ? self::$selfJoinCount++ : self::$selfJoinCount);
 	}
 
 	/**


### PR DESCRIPTION
Fixes error where getRelationCountHash is not compatible with the extended relation.php file from Illminate/Eloquent/Relations/Relation.php in Laravel v8.17.0